### PR TITLE
Fix: Package name could conflict with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 superfluid.py is an application framework for interacting with the Superfluid Protocol using the Python Programming Language.
 
+This is a friendly fork that adds support for the Base blockchain. It may be deprecated once [merged upstream](https://github.com/Godspower-Eze/superfluid.py/pull/1).
+
 # Features
 
 * Minimal Framework initialization (`rpc` and `chain id`)

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md") as f:
     long_description = f.read()
 
 setup(
-    name="superfluid",
-    version="0.2.0",
-    description="Python SDK for the Superfluid Protocol",
+    name="aleph-superfluid",
+    version="0.2.1",
+    description="Fork of the Python SDK for the Superfluid Protocol",
     package_dir={"": "main"},
     packages=find_packages(where="main"),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/Godspower-Eze/superfluid.py",
+    url="https://github.com/aleph-im/superfluid.py",
     author="Godspower-Eze",
     author_email="Godspowereze260@gmail.com",
     license="MIT",


### PR DESCRIPTION
Problem: The package name "superfluid" could
conflict with the upstream.

Solution: Rename the package as "aleph-superfluid" to remove the conflict in installation.

Usage and imports are unchanged.